### PR TITLE
feat(async-pack): support only custom dynamic packages

### DIFF
--- a/packages/taro-plugin-async-pack/README.md
+++ b/packages/taro-plugin-async-pack/README.md
@@ -153,6 +153,8 @@ const AsyncComponent = defineAsyncComponent(() => import('./async-component')
 | `dynamicPackageNamePrefix` | `string`                 | `'dynamic-package'` | 异步分包名称前缀  |
 | `dynamicPackageCount`      | `number`                 | `1`                | 异步分包数量    |
 | `customDynamicPackages`    | `CustomDynamicPackage[]` | `[]`               | 自定义异步分包配置 |
+| `onlyCustomDynamicPackages` | `boolean`               | `false`            | 是否只处理命中自定义异步分包的模块 |
+| `strictCustomDynamicPackages` | `boolean`             | `false`            | 开启 `onlyCustomDynamicPackages` 后，未命中自定义异步分包的异步模块是否直接构建失败 |
 
 ### `customDynamicPackages` 配置说明
 
@@ -191,6 +193,37 @@ plugins: [
 ```
 
 上述配置会额外生成 `dynamic-package-sync-style` 和 `dynamic-package-async-style` 两个异步分包；其中 `async-style` 分包会同时产出 `inject-style` 组件，并在编译时自动追加到 `app.json` 与页面模板中。
+
+### `onlyCustomDynamicPackages`
+
+是否只处理命中 `customDynamicPackages` 的异步模块。
+
+默认值：`false`
+
+当设置为 `true` 时，插件不会生成 `dynamic-package-default` 这类默认异步分包，也不会把未命中的 `import()` chunk 自动移动到默认异步分包中。未命中的异步 chunk 会继续使用原始 webpack / Taro 的 `chunkFilename` 与加载逻辑。
+
+这个配置适合只想异步加载少量指定 SDK、组件或低频功能模块的项目，例如地图 SDK、风控 SDK、埋点 SDK、直播 SDK 或编辑器模块。
+
+```js
+plugins: [
+  ['@taro-minify-pack/plugin-async-pack', {
+    dynamicPackageNamePrefix: 'dynamic-package',
+    onlyCustomDynamicPackages: true,
+    customDynamicPackages: [
+      {
+        name: 'heavy-sdk',
+        test: (module) => /node_modules[\\/]heavy-sdk/.test(module.identifier())
+      }
+    ]
+  }]
+]
+```
+
+### `strictCustomDynamicPackages`
+
+默认值：`false`
+
+只有同时开启 `onlyCustomDynamicPackages` 时该配置才有意义。设置为 `true` 后，一旦存在未命中 `customDynamicPackages` 的异步 chunk，插件会直接让构建失败，并提示该 chunk 没有配置到自定义异步分包中。
 
 ## 🤝 常见问题
 

--- a/packages/taro-plugin-async-pack/src/index.ts
+++ b/packages/taro-plugin-async-pack/src/index.ts
@@ -23,7 +23,9 @@ export * from './inject-dynamic-style'
 const dynamicPackOptsDefaultOpt: AsyncPackOpts = {
   dynamicPackageNamePrefix: 'dynamic-package',
   dynamicPackageCount: 1,
-  customDynamicPackages: []
+  customDynamicPackages: [],
+  onlyCustomDynamicPackages: false,
+  strictCustomDynamicPackages: false
 }
 
 export default (ctx: IPluginContext, pluginOpts: Partial<AsyncPackOpts>) => {
@@ -34,6 +36,7 @@ export default (ctx: IPluginContext, pluginOpts: Partial<AsyncPackOpts>) => {
   ctx.modifyWebpackChain(({ chain }) => {
     // 动态获取现有的 splitChunks 配置
     const existingSplitChunks = chain.optimization.get('splitChunks') || {}
+    const originalJsChunkFilename = chain.output.get('chunkFilename')
 
     const { common, vendors } = existingSplitChunks.cacheGroups
 
@@ -63,7 +66,12 @@ export default (ctx: IPluginContext, pluginOpts: Partial<AsyncPackOpts>) => {
 
     chain.merge({
       output: {
-        chunkFilename: (pathData: PathData) => generateChunkFilename({ ...finalOpts, pathData, ext: '.js' }),
+        chunkFilename: (pathData: PathData) => generateChunkFilename({
+          ...finalOpts,
+          pathData,
+          ext: '.js',
+          originalChunkFilename: originalJsChunkFilename
+        }),
         path: ctx.paths.outputPath,
         clean: true
       }
@@ -72,7 +80,13 @@ export default (ctx: IPluginContext, pluginOpts: Partial<AsyncPackOpts>) => {
     chain.plugin('miniCssExtractPlugin')
       .tap((args) => {
         const [options] = args
-        const chunkFilename = (pathData: PathData) => generateChunkFilename({ ...finalOpts, pathData, ext: '.wxss' })
+        const originalStyleChunkFilename = options.chunkFilename
+        const chunkFilename = (pathData: PathData) => generateChunkFilename({
+          ...finalOpts,
+          pathData,
+          ext: '.wxss',
+          originalChunkFilename: originalStyleChunkFilename
+        })
         return [{ ...options, chunkFilename }]
       })
 

--- a/packages/taro-plugin-async-pack/src/transform-app-config.ts
+++ b/packages/taro-plugin-async-pack/src/transform-app-config.ts
@@ -18,7 +18,7 @@ export const transformAppConfig = (opts: Opts) => {
 
   const finalSubPackages = subPackages || subpackages || []
 
-  const defaultDynamicPackagesConfig = new Array(dynamicPackageCount).fill(null).map((_, order) => {
+  const defaultDynamicPackagesConfig = opts.onlyCustomDynamicPackages ? [] : new Array(dynamicPackageCount).fill(null).map((_, order) => {
     return { root: generateDefaultDynamicPackageName({ ...opts, order }), pages: [] }
   })
 

--- a/packages/taro-plugin-async-pack/src/transform-webpack-runtime.ts
+++ b/packages/taro-plugin-async-pack/src/transform-webpack-runtime.ts
@@ -54,6 +54,30 @@ const webpackLoadDynamicModuleTemplate = `
   };
 `
 
+const webpackLoadDynamicModuleFallbackTemplate = `
+  __webpack_require__.l = function (dynamicModulePath, done, key, chunkId) {
+    var loadDynamicModuleFn = loadDynamicModuleFnMap[dynamicModulePath];
+    if (!loadDynamicModuleFn) return originLoadScript(dynamicModulePath, done, key, chunkId);
+
+    if (inProgress[dynamicModulePath]) {
+      inProgress[dynamicModulePath].push(done);
+      return;
+    }
+
+    const target = { src: dynamicModulePath };
+
+    if (loadedDynamicModules[dynamicModulePath]) return done({ type: 'loaded', target });
+
+    promiseRetry(function () {
+      return loadDynamicModuleFn()
+    }).then(function () {
+      return done({ type: 'loaded', target })
+    }).catch(function () {
+      return done({ type:'error', target })
+    });
+  };
+`
+
 const replaceWebpackLoadScriptFn = (assignmentExpressionNodePath: NodePath<AssignmentExpression>, opts: Opts) => {
   const { left, right } = assignmentExpressionNodePath.node || {}
 
@@ -85,11 +109,18 @@ const replaceWebpackLoadScriptFn = (assignmentExpressionNodePath: NodePath<Assig
     return `var loadDynamicModuleFnMap = {${dynamicAssetsRequireTempCode.join(',')}}`
   })()
 
-  const templateCodeAst = template.ast(webpackLoadDynamicModuleTemplate) as Statement
+  const templateCodeAst = template.ast(opts.onlyCustomDynamicPackages ? webpackLoadDynamicModuleFallbackTemplate : webpackLoadDynamicModuleTemplate) as Statement
 
   const loadDynamicModuleFnMapAst = template.ast(loadDynamicModuleFnMapCode)
 
   const templateCodeDepAst = template.ast(webpackLoadDynamicModuleTemplateDep)
+
+  if (opts.onlyCustomDynamicPackages) {
+    const originLoadScriptAst = types.variableDeclaration('var', [
+      types.variableDeclarator(types.identifier('originLoadScript'), types.cloneNode(right))
+    ])
+    assignmentExpressionNodePath.insertBefore(originLoadScriptAst)
+  }
 
   assignmentExpressionNodePath.replaceWith(templateCodeAst)
 

--- a/packages/taro-plugin-async-pack/src/types.ts
+++ b/packages/taro-plugin-async-pack/src/types.ts
@@ -16,6 +16,8 @@ export interface AsyncPackOpts {
     dynamicPackageNamePrefix: string;
     dynamicPackageCount: number;
     customDynamicPackages: CustomDynamicPackage[]
+    onlyCustomDynamicPackages?: boolean
+    strictCustomDynamicPackages?: boolean
 }
 
 export type CompilationAssets = Record<string, Source>;

--- a/packages/taro-plugin-async-pack/src/utils.ts
+++ b/packages/taro-plugin-async-pack/src/utils.ts
@@ -1,6 +1,8 @@
 import { AsyncPackOpts } from './types'
 import type { PathData } from 'webpack'
 
+type ChunkFilename = string | ((pathData: PathData) => string)
+
 export const hashModBigInt = (hash: string, mod: number) => {
   if (!hash || mod <= 0) return 0
   return Number(BigInt('0x' + hash) % BigInt(mod))
@@ -22,8 +24,26 @@ export const generateCustomDynamicPackageName = (opt: AsyncPackOpts, packageName
   return `${opt.dynamicPackageNamePrefix}-${packageName}`
 }
 
-export const generateChunkFilename = (opt: AsyncPackOpts & { pathData: PathData, ext: string }) => {
+const generateOriginalChunkFilename = (opt: { pathData: PathData, ext: string, originalChunkFilename?: ChunkFilename }) => {
+  if (typeof opt.originalChunkFilename === 'function') return opt.originalChunkFilename(opt.pathData)
+  if (typeof opt.originalChunkFilename === 'string') return opt.originalChunkFilename
+  return `[id]${opt.ext}`
+}
+
+export const generateChunkFilename = (opt: AsyncPackOpts & { pathData: PathData, ext: string, originalChunkFilename?: ChunkFilename }) => {
   const { chunk } = opt.pathData
+  const chunkName = chunk?.name
+
+  if (opt.onlyCustomDynamicPackages) {
+    if (chunkName && isCustomDynamicPackageAsset(opt, `${chunkName}${opt.ext}`)) return `${chunkName}${opt.ext}`
+
+    if (opt.strictCustomDynamicPackages) {
+      throw new Error(`[plugin-async-pack] unmatched async chunk${chunkName ? ` "${chunkName}"` : ''} is not configured in customDynamicPackages`)
+    }
+
+    return generateOriginalChunkFilename(opt)
+  }
+
   if (chunk?.name) return `${chunk?.name}${opt.ext}`
   const order = hashModBigInt(chunk?.hash || '', opt.dynamicPackageCount)
   return `${generateDefaultDynamicPackageName({ ...opt, order })}/[chunkhash]${opt.ext}`
@@ -34,6 +54,7 @@ export const isNumber = (val: any) => {
 }
 
 export const isDefaultDynamicPackageAsset = (opt: AsyncPackOpts, assetName: string) => {
+  if (opt.onlyCustomDynamicPackages) return false
   const dynamicModuleRegExp = new RegExp(`^${opt.dynamicPackageNamePrefix}(?:-([a-z]{2}|default))?/`)
   return dynamicModuleRegExp.test(assetName)
 }

--- a/packages/taro-preset/README.md
+++ b/packages/taro-preset/README.md
@@ -189,6 +189,8 @@ module.exports = {
 | dynamicPackageNamePrefix | `string`                 | `'dynamic-package'` | 动态包名称前缀   |
 | dynamicPackageCount      | `number`                 | `1`                 | 动态包数量     |
 | customDynamicPackages    | `CustomDynamicPackage[]` | `[]`                | 自定义异步分包配置 |
+| onlyCustomDynamicPackages | `boolean`               | `false`             | 是否只处理命中自定义异步分包的模块 |
+| strictCustomDynamicPackages | `boolean`             | `false`             | 开启 `onlyCustomDynamicPackages` 后，未命中的异步模块是否直接构建失败 |
 
 ### remoteAssets 配置
 


### PR DESCRIPTION
## 背景

当前 `plugin-async-pack` 已支持通过 `customDynamicPackages` 将命中的异步模块放入自定义动态分包，例如把地图 SDK、风控 SDK、埋点 SDK、直播 SDK、编辑器等重模块单独拆出。

但在现有行为下，未命中 `customDynamicPackages` 的其他异步 chunk 仍会被放入默认动态分包，例如 `dynamic-package-default`。对于只想保守接入少量指定重模块的项目来说，这会额外改变原有 `import()` chunk 的加载方式。

## 改动内容

本 PR 新增两个配置项：

```ts
onlyCustomDynamicPackages?: boolean
strictCustomDynamicPackages?: boolean
```

默认值均为 `false`，因此现有用户不受影响。

### onlyCustomDynamicPackages

当设置为 `true` 时：

- 命中 `customDynamicPackages` 的异步 chunk 仍会进入对应自定义动态分包
- 未命中的异步 chunk 不再进入默认动态分包
- 不再向 `app.json` 注入默认动态分包配置，例如 `dynamic-package-default`
- 未命中的异步 chunk 会回退到原始 webpack / Taro 的 `chunkFilename` 与加载逻辑
- runtime loader 对动态包映射中不存在的 chunk 会调用原始 `__webpack_require__.l`

### strictCustomDynamicPackages

当同时开启：

```ts
onlyCustomDynamicPackages: true,
strictCustomDynamicPackages: true
```

如果存在未命中 `customDynamicPackages` 的异步 chunk，构建会直接失败，并提示该 chunk 未配置到自定义动态分包中。

## 行为对比

默认行为保持不变：

```txt
customDynamicPackages 命中的异步 chunk -> 自定义动态分包
其他异步 chunk -> 默认动态分包
```

开启 `onlyCustomDynamicPackages` 后：

```txt
customDynamicPackages 命中的异步 chunk -> 自定义动态分包
其他异步 chunk -> 原始 webpack/Taro 加载行为
```

同时开启 strict 后：

```txt
customDynamicPackages 命中的异步 chunk -> 自定义动态分包
其他异步 chunk -> 构建失败
```

## 文档

补充了：

- `@taro-minify-pack/plugin-async-pack` README 配置说明
- `@taro-minify-pack/taro-preset` README 中的 `asyncPack` 配置表

## 验证

已执行：

```bash
pnpm --filter @taro-minify-pack/plugin-async-pack build
git diff --check
```

结果均通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增两个配置选项，支持精细化异步包分割控制：仅将匹配的模块分割为自定义异步子包，以及在构建时校验所有异步块的配置覆盖情况。

* **文档**
  * 更新配置文档，补充新选项的详细说明、示例用法及默认值。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panyu97py/taro-minify-pack/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->